### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ProtectWise
 
-Publisher: Splunk \
-Connector Version: 2.1.2 \
-Product Vendor: ProtectWise \
-Product Name: ProtectWise \
+Publisher: Splunk <br>
+Connector Version: 2.1.2 <br>
+Product Vendor: ProtectWise <br>
+Product Name: ProtectWise <br>
 Minimum Product Version: 6.2.1
 
 This app integrates with the ProtectWise cloud platform to implement ingestion and investigative actions
@@ -82,18 +82,18 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity \
-[get pcap](#action-get-pcap) - Download pcap for an event or observation \
-[hunt ip](#action-hunt-ip) - Hunt an IP in the network \
-[hunt domain](#action-hunt-domain) - Hunt a domain in the network \
-[hunt file](#action-hunt-file) - Hunt for a file in the network \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity <br>
+[get pcap](#action-get-pcap) - Download pcap for an event or observation <br>
+[hunt ip](#action-hunt-ip) - Hunt an IP in the network <br>
+[hunt domain](#action-hunt-domain) - Hunt a domain in the network <br>
+[hunt file](#action-hunt-file) - Hunt for a file in the network <br>
 [on poll](#action-on-poll) - Query ProtectWise for Events and Observables and ingest into Splunk SOAR
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -108,7 +108,7 @@ No Output
 
 Download pcap for an event or observation
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 A few things to note:<ul><li>Valid values for the <b>type</b> parameter are: <ul><li>Event</li><li>Observation</li></ul></li><li>The app adds the <i>Event ID</i> to every container as its <b>Source ID</b>(source_data_identifier)<a href="/app_resource/protectwise_e8f8d8dc-916f-4267-be15-e9b697dd58c5/img/sdi.png"><img src="/app_resource/protectwise_e8f8d8dc-916f-4267-be15-e9b697dd58c5/img/sdi.png"/></a><br>Unfortunately, this value can get clipped in the UI. Instead, use the download button to download the container json and extract the source_data_identifier key value<a href="/app_resource/protectwise_e8f8d8dc-916f-4267-be15-e9b697dd58c5/img/sdi2.png"><img src="/app_resource/protectwise_e8f8d8dc-916f-4267-be15-e9b697dd58c5/img/sdi2.png"/></a><br></li><li>The app adds the <i>Observation ID</i> to every Artifact in a key named <b>observationId</b> of the cef dictionary<a href="/app_resource/protectwise_e8f8d8dc-916f-4267-be15-e9b697dd58c5/img/artifact.png"><img src="/app_resource/protectwise_e8f8d8dc-916f-4267-be15-e9b697dd58c5/img/artifact.png"/></a><br></li><li>The <b>sensorid</b> parameter is only required if the <b>type</b> is <b>Observation</b></li><li>The pcap file is added to the vault with a file name of \<<b>id</b>>.pcap</li></ul>.
@@ -150,7 +150,7 @@ summary.total_objects_successful | numeric | | |
 
 Hunt an IP in the network
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 To get info within a time range specify the <b>start_time</b> and <b>end_time</b>. These parameters take time in the Zulu format which can be expressed as %Y-%m-%dT%H:%M:%S.%fZ e.g. 2016-12-30T13:00:00.0000Z.<br><ul><li>If <b>start_time</b> and <b>end_time</b> both are not specified, then the app defaults to last 5 days</li><li>If <b>start_time</b> is specified and <b>end_time</b> is not, then the app will default the <b>end_time</b> to <i>current</i></li><li>If <b>start_time</b> is not specified and <b>end_time</b> is, the app will throw an error</li></ul>.
@@ -433,7 +433,7 @@ action_result.parameter.ph | ph | | |
 
 Hunt a domain in the network
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 To get info within a time range specify the <b>start_time</b> and <b>end_time</b>. These parameters take time in the Zulu format which can be expressed as %Y-%m-%dT%H:%M:%S.%fZ e.g. 2016-12-30T13:00:00.0000Z.<br><ul><li>If <b>start_time</b> and <b>end_time</b> both are not specified, then the app defaults to last 5 days</li><li>If <b>start_time</b> is specified and <b>end_time</b> is not, then the app will default the <b>end_time</b> to <i>current</i></li><li>If <b>start_time</b> is not specified and <b>end_time</b> is, the app will throw an error</li></ul>.
@@ -482,7 +482,7 @@ action_result.parameter.ph | ph | | |
 
 Hunt for a file in the network
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 To get info within a time range specify the <b>start_time</b> and <b>end_time</b>. These parameters take time in the Zulu format which can be expressed as %Y-%m-%dT%H:%M:%S.%fZ e.g. 2016-12-30T13:00:00.0000Z.<br><ul><li>If <b>start_time</b> and <b>end_time</b> both are not specified, then the app defaults to last 5 days</li><li>If <b>start_time</b> is specified and <b>end_time</b> is not, then the app will default the <b>end_time</b> to <i>current</i></li><li>If <b>start_time</b> is not specified and <b>end_time</b> is, the app will throw an error</li></ul>.
@@ -617,7 +617,7 @@ action_result.parameter.ph | ph | | |
 
 Query ProtectWise for Events and Observables and ingest into Splunk SOAR
 
-Type: **ingest** \
+Type: **ingest** <br>
 Read only: **True**
 
 #### Action Parameters

--- a/protectwise.json
+++ b/protectwise.json
@@ -2114,5 +2114,11 @@
             "output": [],
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/protectwise.json
+++ b/protectwise.json
@@ -16,7 +16,7 @@
     "latest_tested_versions": [
         "ProtectWise API v1 06/10/2021"
     ],
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "logo": "logo_protectwise.svg",
     "logo_dark": "logo_protectwise_dark.svg",
     "license": "Copyright (c) 2016-2025 Splunk Inc.",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)